### PR TITLE
Remove `command` property from json in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ Here is an example of the JSON message for the POST request:
 
 ```json
 {
-    "command" : "deploy",
     "applicationId":"subscriptionsaf4cbd2f-24f1-408a-9945-c7594b98c964resourcegroupspabloprovidersmicrosoft.solutionsapplicationsmyupdatableapp",
     "image": "abecaxkqnyv7qh6acr.azurecr.io/ama-update-sample-resources:1673630025"
 }


### PR DESCRIPTION
## Purpose

Removed `command` property from json in readme

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:


## Other Information
The previous payload in the readme was the one used for the `commands` function in the AMA instance. The current payload (without the `command` property) is the right one for the `deployment` function in the publisher's backend 