### PR TITLE
Update siteConfig for function app

### DIFF
--- a/ama/resources/main.bicep
+++ b/ama/resources/main.bicep
@@ -49,6 +49,8 @@ resource appFunction 'Microsoft.Web/sites@2022-03-01' = {
       acrUseManagedIdentityCreds: false
       http20Enabled: true
       linuxFxVersion: 'DOCKER|${dockerImageFullName}'
+      minTlsVersion: '1.2'
+      ftpsState: 'FtpsOnly'
       appSettings: [
         {
           name: 'DOCKER_REGISTRY_SERVER_URL'


### PR DESCRIPTION
This pull request addresses the following security best practices

* [`ama/resources/main.bicep`](diffhunk://#diff-e592d7980407730fc73f5fd7d7f778c259cb9cf28bf1d08ae93b63698aafe357R52-R53): Added `minTlsVersion: '1.2'` to specify the minimum version of TLS to be used.
* [`ama/resources/main.bicep`](diffhunk://#diff-e592d7980407730fc73f5fd7d7f778c259cb9cf28bf1d08ae93b63698aafe357R52-R53): Added `ftpsState: 'FtpsOnly'` to enforce the use of FTPS for file transfers.